### PR TITLE
Support LanguageTool 2.7

### DIFF
--- a/language_check/__init__.py
+++ b/language_check/__init__.py
@@ -45,6 +45,7 @@ __all__ = ['LanguageTool', 'Error', 'get_languages', 'correct', 'get_version',
            'get_directory', 'set_directory']
 
 JAR_NAMES = [
+    'languagetool-server.jar',
     'languagetool-standalone*.jar',    # 2.1
     'LanguageTool.jar',
     'LanguageTool.uno.jar'


### PR DESCRIPTION
The newest possible version is determined during installation:
- Java 7+: LanguageTool 2.7
- Java 6: LanguageTool 2.2

If Java cannot be found or is too old, the installation fails.

Not sure if it's bad style to import from language_check during its installation.
