### PR TITLE
Encode output to UTF-8

### DIFF
--- a/language_check/main.py
+++ b/language_check/main.py
@@ -144,7 +144,7 @@ def main():
                         match.fromy + 1,
                         match.fromx + 1,
                         rule_id,
-                        message))
+                        message)).encode('utf-8')
                     status = 2
         except Error as exception:
             print('{}: {}'.format(filename, exception), file=sys.stderr)


### PR DESCRIPTION
Hello,

When I tried your language-check with Syntastic.vim, I could not get it work at first and I found the cause. So here is an explanation and a fix.

(BTW, integrating grammar checking with Syntastic is so great! Big thanks for your tool :+1: )

---

When piping output, python seems to get confused about encoding and
sets it to None (http://stackoverflow.com/questions/492483/setting-the-correct-encoding-when-piping-stdout-in-python).

This affects Vim's syntastic integration since it uses piping internally (http://stackoverflow.com/questions/22442490/weird-python-encoding-error-in-vim-with-make).

Reproduction step (you may have to `unset PYTHONIOENCODING` beforehand):
```
  % cat hello.txt
  "hello"

  % language-check --language='en-US' hello.txt
  hello.txt:1:1: EN_UNPAIRED_BRACKETS: Unpaired bracket or similar symbol
  hello.txt:1:1: EN_QUOTES[1]: Use a smart opening quote here: '“'.
  hello.txt:1:7: EN_QUOTES[2]: Use a smart closing quote here: '”'.

  % language-check --language='en-US' hello.txt | cat
  Traceback (most recent call last):
    File "/usr/local/bin/language-check", line 6, in <module>
      sys.exit(main.main())
    File "/usr/local/lib/python2.7/site-packages/language_check/main.py", line 150, in main
      message)
  UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 62: ordinal not in range(128)
  hello.txt:1:1: EN_UNPAIRED_BRACKETS: Unpaired bracket or similar symbol
```

With this fix, it works fine with piping:
```
  % language-check --language='en-US' hello.txt | cat
  hello.txt:1:1: EN_UNPAIRED_BRACKETS: Unpaired bracket or similar symbol
  hello.txt:1:1: EN_QUOTES[1]: Use a smart opening quote here: '“'.
  hello.txt:1:7: EN_QUOTES[2]: Use a smart closing quote here: '”'.
```