### PR TITLE
Remote LanguageTool server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+##
+# NAME             : iadvize/language-tools-server
+# VERSION          : 3
+# DOCKER-VERSION   : 1.13
+# DESCRIPTION      : Python runtime v3
+# TO_BUILD         : docker build --pull=true --no-cache --rm -t iadvize/language-tools-server:3.2 -t iadvize/language-tools-server:latest .
+# TO_SHIP          : docker push iadvize/language-tools-server:3.2 && docker push iadvize/language-tools-server:latest
+# TO_RUN           : docker run -ti --rm -p 8080:8080 iadvize/language-tools-server:3.2
+##
+
+FROM java:8
+
+MAINTAINER Samuel Berthe <samuel.berthe@iadvize.com>
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    INITRD="No" \
+    PACKAGES="curl unzip" \
+    LANGUAGE_TOOL_VERSION="3.2"
+
+WORKDIR /app
+EXPOSE 8080
+CMD /usr/bin/java -cp /app/LanguageTool-${LANGUAGE_TOOL_VERSION}/languagetool-server.jar org.languagetool.server.HTTPServer --port 8080 --public
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends $PACKAGES && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app && \
+    curl -L -o /app/LanguageTool-${LANGUAGE_TOOL_VERSION}.zip https://www.languagetool.org/download/LanguageTool-${LANGUAGE_TOOL_VERSION}.zip && \
+    unzip /app/LanguageTool-${LANGUAGE_TOOL_VERSION}.zip && \
+    rm -rf /app/LanguageTool-${LANGUAGE_TOOL_VERSION}.zip

--- a/language_check/main.py
+++ b/language_check/main.py
@@ -44,6 +44,10 @@ def parse_args():
                         help='disable spell-checking rules')
     parser.add_argument('--ignore-lines',
                         help='ignore lines that match this regular expression')
+    parser.add_argument('--remote-host',
+                        help='hostname of the remote LanguageTool server')
+    parser.add_argument('--remote-port',
+                        help='port of the remote LanguageTool server')
 
     args = parser.parse_args()
 
@@ -100,8 +104,13 @@ def main():
         else:
             encoding = args.encoding or 'utf-8'
 
+        remote_server = None
+        if args.remote_host is not None and args.remote_port is not None:
+            remote_server = {'host': args.remote_host, 'port': args.remote_port}
         lang_tool = LanguageTool(
-            motherTongue=args.mother_tongue)
+            motherTongue=args.mother_tongue,
+            remote_server=remote_server,
+        )
         guess_language = None
 
         try:

--- a/test.bash
+++ b/test.bash
@@ -4,19 +4,22 @@
 
 trap "echo -e '\x1b[01;31mFailed\x1b[0m'" ERR
 
-echo 'This is okay.' | language-check -
-! echo 'This is noot okay.' | language-check -
+#export ARGS="--remote-host localhost --remote-port 8080"
+export ARGS=""
 
-echo 'This is okay.' | python -m language_check -
-! echo 'This is noot okay.' | python -m language_check -
+echo 'This is okay.' | language-check ${ARGS} -
+! echo 'This is noot okay.' | language-check ${ARGS} -
 
-echo 'These are “smart” quotes.' | python -m language_check -
-! echo 'These are "dumb" quotes.' | python -m language_check -
-! echo 'These are "dumb" quotes.' | python -m language_check --enabled-only \
+echo 'This is okay.' | python -m language_check ${ARGS} -
+! echo 'This is noot okay.' | python -m language_check ${ARGS} -
+
+echo 'These are “smart” quotes.' | python -m language_check ${ARGS} -
+! echo 'These are "dumb" quotes.' | python -m language_check ${ARGS} -
+! echo 'These are "dumb" quotes.' | python -m language_check ${ARGS} --enabled-only \
     --enable=EN_QUOTES -
-echo 'These are "dumb" quotes.' | python -m language_check --enabled-only \
+echo 'These are "dumb" quotes.' | python -m language_check ${ARGS} --enabled-only \
     --enable=EN_UNPAIRED_BRACKETS -
 
-echo '# These are "dumb".' | python -m language_check --ignore-lines='^#' -
+echo '# These are "dumb".' | python -m language_check ${ARGS} --ignore-lines='^#' -
 
 echo -e '\x1b[01;32mOkay\x1b[0m'


### PR DESCRIPTION
Separate LanguageTool runtime from python library, using client/server remote connection.

```bash
$ docker run -d --name language-tools -p 8080:8080 iadvize/language-tools-server:3.2
$ echo 'This is okay.' | python language-check --remote-host localhost --remote-port 8080 -
$ echo $?
```
