### PR TITLE
Force str for setuptools package_data key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ def get_package_data(value):
         if '=' in line:
             # package name -- file globs or specs
             key, value = line.split('=')
-            prev = package_data[key.strip()] = value.split()
+            prev = package_data[str(key.strip())] = value.split()
         elif firstline:
             # invalid continuation on the first line
             raise ValueError(


### PR DESCRIPTION
When configparser backport is installed on Python 2,
the RawConfigParser uses unicode keys, which setuptools
rejects when they are copied into the package_data dict.

Fixes https://github.com/myint/language-check/issues/30