### PR TITLE
Enforce code style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
     # Prevent Python 2.7 from using the non-3to2 converted code.
     - mv language_check .language_check
 
+    - pip install pycodestyle pylint rstcheck
+
 script:
     - ./test.py
 
@@ -29,3 +31,6 @@ script:
     - echo 'This is a sentence.' > foo.txt
     - language-check foo.txt
     - language-check --version
+
+    - mv .language_check language_check
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then make check; fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 check:
 	pycodestyle \
+		--exclude ./language_check/LanguageTool-* \
 		--ignore=E402 \
 		./language-check \
 		./language_check/ \
@@ -21,6 +22,7 @@ check:
 		--disable=similarities \
 		--disable=too-few-public-methods \
 		--disable=too-many-branches \
+		--disable=too-many-instance-attributes \
 		--disable=too-many-locals \
 		--disable=too-many-statements \
 		--disable=wrong-import-order \

--- a/language_check/main.py
+++ b/language_check/main.py
@@ -106,7 +106,8 @@ def main():
 
         remote_server = None
         if args.remote_host is not None and args.remote_port is not None:
-            remote_server = {'host': args.remote_host, 'port': args.remote_port}
+            remote_server = {'host': args.remote_host,
+                             'port': args.remote_port}
         lang_tool = LanguageTool(
             motherTongue=args.mother_tongue,
             remote_server=remote_server,

--- a/setup.py
+++ b/setup.py
@@ -192,10 +192,10 @@ def split_multiline(value):
 
 def split_elements(value):
     """Split a string with comma or space-separated elements into a list."""
-    l = [v.strip() for v in value.split(',')]
-    if len(l) == 1:
-        l = value.split()
-    return l
+    items = [v.strip() for v in value.split(',')]
+    if len(items) == 1:
+        items = value.split()
+    return items
 
 
 def eval_environ(value):
@@ -541,7 +541,7 @@ def generate_py2k(config, py2k_dir=PY2K_DIR, run_tests=False):
         try:
             run_3to2(copied_py_files)
             write_py2k_header(copied_py_files)
-        except:
+        except Exception:
             shutil.rmtree(py2k_dir)
             raise
 


### PR DESCRIPTION
Resolve a few minor code style issues, for short variable,
bare except, and long lines.

Run `make check` in Python 3.5 Travis job to prevent unintentional
regressions.
Python 2 is not checked as Python 3 syntax is used, and PyPy
has problems with rstcheck, and pylint doesnt support Python 3.6+.