### PR TITLE
Added alternative download url for LanguageTool zip file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,10 @@ If you are using Python 2, you'll need to install 3to2 beforehand::
 
     $ pip install --upgrade 3to2
 
+To overwrite the host part of URL that is used to download LanguageTool-{version}.zip::
+
+    - SET LANGUAGE-CHECK-DOWNLOAD-URL = [alternate URL]
+
 
 Prerequisites
 -------------

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ If you are using Python 2, you'll need to install 3to2 beforehand::
 
 To overwrite the host part of URL that is used to download LanguageTool-{version}.zip::
 
-    - SET LANGUAGE-CHECK-DOWNLOAD-URL = [alternate URL]
+    - SET LANGUAGE_CHECK_DOWNLOAD_URL = [alternate URL]
 
 
 Prerequisites

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ If you are using Python 2, you'll need to install 3to2 beforehand::
 
 To overwrite the host part of URL that is used to download LanguageTool-{version}.zip::
 
-    - SET LANGUAGE_CHECK_DOWNLOAD_URL = [alternate URL]
+    - SET LANGUAGE_CHECK_DOWNLOAD_HOST = [alternate URL]
 
 
 Prerequisites

--- a/download_lt.py
+++ b/download_lt.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+import os
 
 from contextlib import closing
 from distutils.spawn import find_executable
@@ -23,7 +24,7 @@ except ImportError:
     from urlparse import urljoin
 
 
-BASE_URL = 'https://www.languagetool.org/download/'
+BASE_URL = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST'] or 'https://www.languagetool.org/download/'
 FILENAME = 'LanguageTool-{version}.zip'
 PACKAGE_PATH = 'language_check'
 JAVA_6_COMPATIBLE_VERSION = '2.2'

--- a/download_lt.py
+++ b/download_lt.py
@@ -117,6 +117,7 @@ def download_lt(update=False):
 
     version = get_newest_possible_languagetool_version()
     filename = FILENAME.format(version=version)
+    alt_base_url = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST']
     url = urljoin(BASE_URL, filename)
     dirname = os.path.splitext(filename)[0]
     extract_path = os.path.join(PACKAGE_PATH, dirname)

--- a/download_lt.py
+++ b/download_lt.py
@@ -23,7 +23,9 @@ except ImportError:
     from urllib import urlopen
     from urlparse import urljoin
 
-ALT_BASE_URL = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST'] if os.environ.get('LANGUAGE_CHECK_DOWNLOAD_HOST') else None
+ALT_BASE_URL = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST'] \
+    if os.environ.get('LANGUAGE_CHECK_DOWNLOAD_HOST') \
+    else None
 BASE_URL = ALT_BASE_URL or 'https://www.languagetool.org/download/'
 FILENAME = 'LanguageTool-{version}.zip'
 PACKAGE_PATH = 'language_check'

--- a/download_lt.py
+++ b/download_lt.py
@@ -117,7 +117,6 @@ def download_lt(update=False):
 
     version = get_newest_possible_languagetool_version()
     filename = FILENAME.format(version=version)
-    alt_base_url = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST']
     url = urljoin(BASE_URL, filename)
     dirname = os.path.splitext(filename)[0]
     extract_path = os.path.join(PACKAGE_PATH, dirname)

--- a/download_lt.py
+++ b/download_lt.py
@@ -23,8 +23,8 @@ except ImportError:
     from urllib import urlopen
     from urlparse import urljoin
 
-
-BASE_URL = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST'] or 'https://www.languagetool.org/download/'
+ALT_BASE_URL = os.environ['LANGUAGE_CHECK_DOWNLOAD_HOST'] if os.environ.get('LANGUAGE_CHECK_DOWNLOAD_HOST') else None
+BASE_URL = ALT_BASE_URL or 'https://www.languagetool.org/download/'
 FILENAME = 'LanguageTool-{version}.zip'
 PACKAGE_PATH = 'language_check'
 JAVA_6_COMPATIBLE_VERSION = '2.2'


### PR DESCRIPTION
Install fails when behind a corporate firewall that does not allow for Internet access.  PYPI is proxied so the package can be downloaded but the install step that goes out to https://www.languagetool.org/download/ will fail.  

Following the pattern of other packages that does install downloads such as PUPPETEER and NODE-SASS, I modified code to use an ENVIRONMENT VARIABLE to set an alternative download host URL.