### PR TITLE
Update download_lt.py

### DIFF
--- a/download_lt.py
+++ b/download_lt.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import os
+import requests
 
 from contextlib import closing
 from distutils.spawn import find_executable
@@ -128,7 +129,7 @@ def download_lt(update=False):
         return
 
     with closing(TemporaryFile()) as t:
-        with closing(urlopen(url)) as u:
+        with closing(requests.get(url)) as u:
             content_len = int(u.headers['Content-Length'])
 
             sys.stdout.write(
@@ -140,7 +141,7 @@ def download_lt(update=False):
             chunk_len = content_len // 100
             data_len = 0
             while True:
-                data = u.read(chunk_len)
+                data = u.iter_content(chunk_size=chunk_len, decode_unicode=False)
                 if not data:
                     break
                 data_len += len(data)

--- a/download_lt.py
+++ b/download_lt.py
@@ -129,7 +129,7 @@ def download_lt(update=False):
         return
 
     with closing(TemporaryFile()) as t:
-        with closing(requests.get(url)) as u:
+        with closing(requests.get(url,stream=True)) as u:
             content_len = int(u.headers['Content-Length'])
 
             sys.stdout.write(
@@ -140,10 +140,7 @@ def download_lt(update=False):
 
             chunk_len = content_len // 100
             data_len = 0
-            while True:
-                data = u.iter_content(chunk_size=chunk_len, decode_unicode=False)
-                if not data:
-                    break
+            for data in u.iter_content(chunk_len):
                 data_len += len(data)
                 t.write(data)
                 sys.stdout.write(


### PR DESCRIPTION
This is probably because of mod_security or some similar server security feature which blocks known spider/bot user agents (urllib uses something like python urllib/3.3.0, it's easily detected) #78 #76
